### PR TITLE
refractor API Client

### DIFF
--- a/jellybench_py/api.py
+++ b/jellybench_py/api.py
@@ -24,6 +24,8 @@ import requests
 from requests.adapters import HTTPAdapter
 from urllib3.util.retry import Retry
 
+from jellybench_py.util import format_time
+
 
 class ApiError(Exception):
     """Custom exception for API errors."""
@@ -54,8 +56,9 @@ class ApiClient:
         retries = Retry(
             total=3,
             backoff_factor=0.3,
-            status_forcelist=[429, 500, 502, 503, 504],
+            status_forcelist=[500, 502, 503, 504],
             allowed_methods=["GET", "POST"],
+            respect_retry_after_header=False,
         )
         adapter = HTTPAdapter(max_retries=retries)
         self.session.mount("http://", adapter)
@@ -100,6 +103,16 @@ class ApiClient:
             return response.json()
         except (requests.RequestException, JSONDecodeError) as e:
             self.logger.error("Error fetching test data: %s", e)
+            retry_after = None
+            if isinstance(e, requests.exceptions.HTTPError) and e.response is not None:
+                if e.response.status_code == 429:
+                    retry_after = format_time(
+                        int(e.response.headers.get("Retry-After", "0"))
+                    )
+                    self.logger.error(f"Server send retry_after: {retry_after}")
+                    raise ApiError(
+                        f"Too many requests - retry after {retry_after} secconds"
+                    ) from e
             raise ApiError("Failed to fetch test data") from e
 
     def upload(self, data: Dict[str, Any]) -> Dict[str, Any]:

--- a/jellybench_py/api.py
+++ b/jellybench_py/api.py
@@ -8,6 +8,7 @@ from urllib3.util.retry import Retry
 
 class ApiError(Exception):
     """Custom exception for API errors."""
+
     pass
 
 
@@ -22,7 +23,7 @@ class ApiClient:
         """
         if not server_url.startswith("http"):
             raise ValueError("Invalid server URL provided.")
-        
+
         self.server_url = server_url.rstrip("/")
         self.timeout = timeout
         self.logger = logger
@@ -95,7 +96,9 @@ class ApiClient:
         headers = {"Accept": "text/plain", "Content-Type": "application/json"}
 
         try:
-            response = self.session.post(api_url, json=data, headers=headers, timeout=self.timeout)
+            response = self.session.post(
+                api_url, json=data, headers=headers, timeout=self.timeout
+            )
             response.raise_for_status()
             self.logger.info("Upload successful")
             return {

--- a/jellybench_py/api.py
+++ b/jellybench_py/api.py
@@ -1,130 +1,112 @@
-#!/usr/bin/env python3
-
-# jellybench_py.api.py
-# A transcoding hardware benchmarking client (for Jellyfin)
-#    Copyright (C) 2024 BotBlake <B0TBlake@protonmail.com>
-#
-#    This program is free software: you can redistribute it and/or modify
-#    it under the terms of the GNU General Public License as published by
-#    the Free Software Foundation, version 3 of the License.
-#
-#    This program is distributed in the hope that it will be useful,
-#    but WITHOUT ANY WARRANTY; without even the implied warranty of
-#    MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
-#    GNU General Public License for more details.
-#
-#    You should have received a copy of the GNU General Public License
-#    along with this program.  If not, see <https://www.gnu.org/licenses/>.
-#
-##########################################################################################
-from json import JSONDecodeError, dumps, load
+from json import JSONDecodeError
+from typing import Any, Dict, List
 
 import requests
-
-from jellybench_py.constant import Style
-from jellybench_py.util import styled
-
-
-def getPlatform(server_url: str) -> list:
-    print("| Fetch Supported Platforms...", end="")
-    platforms = None
-    response = requests.get(f"{server_url}/api/v1/TestDataApi/Platforms")
-    if response.status_code == 200:
-        print(" success!")
-        platforms = response.json()
-    else:
-        print(" Error")
-        print(f"ERROR: Server replied with {response.status_code}")
-        input("Press any key to exit")
-        exit()
-    platforms = platforms["platforms"]
-    return platforms
+from requests.adapters import HTTPAdapter
+from urllib3.util.retry import Retry
 
 
-def getTestData(platformID: str, platforms_data: list, server_url: str) -> tuple:
-    valid = True
-    print("| Loading tests... ", end="")
+class ApiError(Exception):
+    """Custom exception for API errors."""
+    pass
 
-    # DevMode File Loading
-    if platformID == "local" and platforms_data == "local":
-        try:
-            with open(server_url, "r") as file:
-                data = load(file)
-                print(" success!")
-                return valid, data
-        except JSONDecodeError:
-            print(" Error")
-            print()
-            print(
-                styled(
-                    "ERROR: Failed to decode JSON. Please check the file format.",
-                    [Style.RED, Style.BOLD],
-                )
-            )
-            input("Press any key to exit")
-            exit()
-        return False, None
 
-    current_platform = None
-    for platform in platforms_data:
-        if platform["id"] == platformID and platform["supported"]:
-            current_platform = platform["id"]
-    if not current_platform:
-        print(" Error")
-        print("ERROR: Your Platform isnt Supported.")
-        input("Press any key to exit")
-        exit()
+class ApiClient:
+    def __init__(self, server_url: str, logger, timeout: int = 10) -> None:
+        """
+        Initializes the API client.
 
-    response = requests.get(
-        f"{server_url}/api/v1/TestDataApi?platformId={current_platform}"
-    )
-    if response.status_code == 200:
-        print(" success!")
-        test_data = response.json()
-    elif response.status_code == 429:
-        print(" Error")
-        print(f"ERROR: Server replied with {response.status_code}")
-        ratelimit_time = response.headers["retry-after"]
-        print(f"Ratelimited: Retry in {ratelimit_time}s")
-        exit(1)
-    else:
-        print(" Error")
-        print(
-            styled(
-                f"ERROR: Server replied with {response.status_code}",
-                [Style.RED, Style.BOLD],
-            )
+        :param server_url: The base URL of the API.
+        :param logger: Logger instance, created using the `create_logger` function.
+        :param timeout: Request timeout in seconds.
+        """
+        if not server_url.startswith("http"):
+            raise ValueError("Invalid server URL provided.")
+        
+        self.server_url = server_url.rstrip("/")
+        self.timeout = timeout
+        self.logger = logger
+        self.session = requests.Session()
+        self._configure_session()
+
+    def _configure_session(self) -> None:
+        """Configures a session with automatic retries for network errors."""
+        retries = Retry(
+            total=3,
+            backoff_factor=0.3,
+            status_forcelist=[429, 500, 502, 503, 504],
+            allowed_methods=["GET", "POST"],
         )
-        input("Press any key to exit")
-        exit()
-    return valid, test_data
+        adapter = HTTPAdapter(max_retries=retries)
+        self.session.mount("http://", adapter)
+        self.session.mount("https://", adapter)
+        self.session.verify = True  # Ensure SSL certificate verification
 
+    def get_platforms(self) -> List[Dict[str, Any]]:
+        """
+        Fetches the list of supported platforms from the API.
 
-def upload(server_url: str, data: dict):
-    api_url = f"{server_url}/api/v1/SubmissionApi"
-    print(f"| Uploading to {server_url}... ", end="")
+        :return: A list of platform dictionaries.
+        :raises ApiError: If the request fails.
+        """
+        url = f"{self.server_url}/api/v1/TestDataApi/Platforms"
+        self.logger.info("Fetching supported platforms from %s", url)
 
-    headers = {"accept": "text/plain", "Content-Type": "application/json"}
+        try:
+            response = self.session.get(url, timeout=self.timeout)
+            response.raise_for_status()
+            platforms_data = response.json()
+            platforms = platforms_data.get("platforms", [])
+            self.logger.info("Fetched %d platforms", len(platforms))
+            return platforms
+        except (requests.RequestException, JSONDecodeError) as e:
+            self.logger.error("Error fetching platforms: %s", e)
+            raise ApiError("Failed to fetch platforms") from e
 
-    response = requests.post(api_url, json=data, headers=headers)
-    if response.ok:
-        print(" success!")
-    else:
-        print(" Error")
-    print()
+    def get_test_data(self, platform_id: str) -> Dict[str, Any]:
+        """
+        Fetches test data for the given platform ID.
 
-    # Display detailed information about the response
-    print("\n--- Response Details ---")
-    print(f"URL: {response.url}")
-    print(f"Status Code: {response.status_code}")
-    print(f"Reason: {response.reason}")
-    print(f"Headers: {dumps(dict(response.headers), indent=4)}")
-    print(f"Elapsed Time: {response.elapsed}")
+        :param platform_id: The platform ID for which to retrieve test data.
+        :return: A dictionary containing test data.
+        :raises ApiError: If the request fails.
+        """
+        url = f"{self.server_url}/api/v1/TestDataApi?platformId={platform_id}"
+        self.logger.info("Fetching test data for platform %s from %s", platform_id, url)
 
-    # Display the raw response content
-    print("\n--- Raw Response Content ---")
-    print(response.content)
+        try:
+            response = self.session.get(url, timeout=self.timeout)
+            response.raise_for_status()
+            return response.json()
+        except (requests.RequestException, JSONDecodeError) as e:
+            self.logger.error("Error fetching test data: %s", e)
+            raise ApiError("Failed to fetch test data") from e
 
-    # Display the text response (decoded from bytes)
-    print("\n--- Text Response Content ---")
-    print(response.text)
+    def upload(self, data: Dict[str, Any]) -> Dict[str, Any]:
+        """
+        Uploads benchmark results to the API.
+
+        :param data: The benchmark result data to be uploaded.
+        :return: A dictionary containing server response details.
+        :raises ApiError: If the request fails.
+        """
+        api_url = f"{self.server_url}/api/v1/SubmissionApi"
+        self.logger.info("Uploading data to %s", api_url)
+        headers = {"Accept": "text/plain", "Content-Type": "application/json"}
+
+        try:
+            response = self.session.post(api_url, json=data, headers=headers, timeout=self.timeout)
+            response.raise_for_status()
+            self.logger.info("Upload successful")
+            return {
+                "url": response.url,
+                "status_code": response.status_code,
+                "reason": response.reason,
+                "headers": dict(response.headers),
+                "elapsed": response.elapsed.total_seconds(),
+                "content": response.content,
+                "text": response.text,
+            }
+        except requests.RequestException as e:
+            self.logger.error("Upload failed: %s", e)
+            raise ApiError("Failed to upload data") from e

--- a/jellybench_py/api.py
+++ b/jellybench_py/api.py
@@ -1,3 +1,22 @@
+#!/usr/bin/env python3
+
+# jellybench_py.api.py
+# A transcoding hardware benchmarking client (for Jellyfin)
+#    Copyright (C) 2024 BotBlake <B0TBlake@protonmail.com>
+#
+#    This program is free software: you can redistribute it and/or modify
+#    it under the terms of the GNU General Public License as published by
+#    the Free Software Foundation, version 3 of the License.
+#
+#    This program is distributed in the hope that it will be useful,
+#    but WITHOUT ANY WARRANTY; without even the implied warranty of
+#    MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+#    GNU General Public License for more details.
+#
+#    You should have received a copy of the GNU General Public License
+#    along with this program.  If not, see <https://www.gnu.org/licenses/>.
+#
+##########################################################################################
 from json import JSONDecodeError
 from typing import Any, Dict, List
 

--- a/jellybench_py/core.py
+++ b/jellybench_py/core.py
@@ -28,7 +28,8 @@ from shutil import get_terminal_size, rmtree, unpack_archive
 import progressbar
 import requests
 
-from jellybench_py import api, hwi, worker
+from jellybench_py import hwi, worker
+from jellybench_py.api import ApiClient, ApiError
 from jellybench_py.constant import Constants, Style
 from jellybench_py.util import (
     confirm,
@@ -459,7 +460,7 @@ def check_driver_limit(device: dict, ffmpeg_binary: str, gpu_idx: int):
     return limited_driver, skip_device
 
 
-def output_json(data, file_path, server_url):
+def output_json(data, file_path, api_client):
     # Write the data to the JSON file
     if file_path:
         main_log.info(f"Storing results in {file_path}")
@@ -471,7 +472,7 @@ def output_json(data, file_path, server_url):
     else:
         # upload to server
         main_log.info(f"Uploading results to {args.server_url}")
-        api.upload(server_url, data)
+        api_client.upload(data)
 
 
 def only_do_upload_flow():
@@ -494,7 +495,21 @@ def only_do_upload_flow():
         print("Error: The file is not a valid JSON.")
         exit()
     main_log.info(f"Uploading {output_file} to {args.server_url}")
-    api.upload(args.server_url, data)
+    
+    try:
+        api_client = ApiClient(args.server_url, main_log)  # Initialize API client
+        api_client.upload(data)  # Fetch supported platforms
+    except ValueError as e:
+        main_log.error("Invalid API URL: %s", e)
+        print("\nERROR: Invalid Server URL")
+        input("Press any key to exit")
+        exit()
+    except ApiError as e:
+        main_log.error("API request failed: %s", e)
+        print("\nERROR: Could not retrieve platform data")
+        input("Press any key to exit")
+        exit()
+
     exit()
 
 
@@ -637,37 +652,33 @@ def cli() -> None:
         print()
     print(styled("System Initialization", [Style.BOLD]))
 
-    if not args.server_url.startswith("http") and args.debug_flag:
-        if os.path.exists(args.server_url):
-            main_log.info(f"Using local test-file ({args.server_url})")
-            print_debug(" Using local test-file")
-            platforms = "local"
-            platform_id = "local"
-        else:
-            print()
-            print("ERROR: Invalid Server URL")
-            input("Press any key to exit")
-            exit()
-    elif not args.server_url.startswith("http"):
-        print()
-        print("ERROR: Invalid Server URL")
+
+    if args.server_url != Constants.DEFAULT_SERVER_URL:
+        print_debug(
+            " Not using official Server!",
+            styled("DO NOT UPLOAD RESULTS!", [Style.RED]),
+        )
+
+    try:
+        api_client = ApiClient(args.server_url, main_log)  # Initialize API client
+        platforms = api_client.get_platforms()  # Fetch supported platforms
+    except ValueError as e:
+        main_log.error("Invalid API URL: %s", e)
+        print("\nERROR: Invalid Server URL")
         input("Press any key to exit")
         exit()
-    else:
-        if args.server_url != Constants.DEFAULT_SERVER_URL:
-            print_debug(
-                " Not using official Server!",
-                styled("DO NOT UPLOAD RESULTS!", [Style.RED]),
-            )
-        platforms = api.getPlatform(
-            args.server_url
-        )  # obtain list of (supported) Platforms + ID's
-        platform_id = hwi.get_platform_id(platforms)
+    except ApiError as e:
+        main_log.error("API request failed: %s", e)
+        print("\nERROR: Could not retrieve platform data")
+        input("Press any key to exit")
+        exit()
 
-        used_platform = next(
-            (item for item in platforms if item["id"] == platform_id), None
-        )
-        main_log.info(f"Using platform {str(used_platform)}")
+    platform_id = hwi.get_platform_id(platforms)
+
+    used_platform = next(
+        (item for item in platforms if item["id"] == platform_id), None
+    )
+    main_log.info(f"Using platform {str(used_platform)}")
 
     print("| Obtaining System Information...", end="")
     system_info = hwi.get_system_info()
@@ -768,11 +779,11 @@ def cli() -> None:
         exit()
 
     # Stop Hardware Selection logic
-
-    valid, server_data = api.getTestData(platform_id, platforms, args.server_url)
-    if not valid:
-        print(f"Cancelled: {server_data}")
-        main_log.error(f"Unabled to get TestData {server_data}")
+    try:
+        server_data = api_client.get_test_data(platform_id)
+    except ApiError as e:
+        print(f"Cancelled: {e}")
+        main_log.error(f"Unabled to get TestData {e}")
         exit()
     print(styled("Done", [Style.GREEN]))
     print()
@@ -943,12 +954,12 @@ def cli() -> None:
         "hwinfo": {"ffmpeg": ffmpeg_data, **system_info},
         "tests": benchmark_data,
     }
-    output_json(result_data, args.output_path, args.server_url)
+    output_json(result_data, args.output_path, api_client)
     if args.output_path:
         if confirm(
             message="Upload results to server?", default=True, automate=skip_prompts
         ):
-            output_json(result_data, None, args.server_url)
+            output_json(result_data, None, api_client)
 
 
 def main():

--- a/jellybench_py/core.py
+++ b/jellybench_py/core.py
@@ -35,7 +35,6 @@ from jellybench_py.util import (
     confirm,
     create_logger,
     create_name,
-    format_time,  # noqa: F401
     get_nvenc_session_limit,
     print_debug,
     resolve_path,

--- a/jellybench_py/core.py
+++ b/jellybench_py/core.py
@@ -473,7 +473,13 @@ def output_json(data, file_path, api_client):
     else:
         # upload to server
         main_log.info(f"Uploading results to {args.server_url}")
-        api_client.upload(data)
+        try:
+            api_client.upload(data)
+        except ApiError as e:
+            main_log.error("API request failed: %s", e)
+            print("\nERROR: Could not retrieve platform data")
+            input("Press any key to exit")
+            exit()
 
 
 def only_do_upload_flow():
@@ -499,7 +505,7 @@ def only_do_upload_flow():
 
     try:
         api_client = ApiClient(args.server_url, main_log)  # Initialize API client
-        api_client.upload(data)  # Fetch supported platforms
+        api_client.upload(data)  # Upload to Server
     except ValueError as e:
         main_log.error("Invalid API URL: %s", e)
         print("\nERROR: Invalid Server URL")

--- a/jellybench_py/core.py
+++ b/jellybench_py/core.py
@@ -35,6 +35,7 @@ from jellybench_py.util import (
     confirm,
     create_logger,
     create_name,
+    format_time,  # noqa: F401
     get_nvenc_session_limit,
     print_debug,
     resolve_path,

--- a/jellybench_py/core.py
+++ b/jellybench_py/core.py
@@ -495,7 +495,7 @@ def only_do_upload_flow():
         print("Error: The file is not a valid JSON.")
         exit()
     main_log.info(f"Uploading {output_file} to {args.server_url}")
-    
+
     try:
         api_client = ApiClient(args.server_url, main_log)  # Initialize API client
         api_client.upload(data)  # Fetch supported platforms
@@ -651,7 +651,6 @@ def cli() -> None:
         )
         print()
     print(styled("System Initialization", [Style.BOLD]))
-
 
     if args.server_url != Constants.DEFAULT_SERVER_URL:
         print_debug(

--- a/jellybench_py/util.py
+++ b/jellybench_py/util.py
@@ -61,6 +61,17 @@ def confirm(
 
     return valid_inputs[response]
 
+def format_time(seconds: int) -> str:
+    if seconds >= 3600:
+        hours = seconds // 3600
+        minutes = (seconds % 3600) // 60
+        return f"{hours}h {minutes}m" if minutes else f"{hours}h"
+    elif seconds >= 60:
+        minutes = seconds // 60
+        sec = seconds % 60
+        return f"{minutes}m {sec}s" if sec else f"{minutes}m"
+    else:
+        return f"{seconds}s"
 
 def get_nvenc_session_limit(driver_version: int) -> int:
     if driver_version >= 550.0:


### PR DESCRIPTION
## Pull Request Status:  
This PR marks the initial step toward transitioning the codebase into a more object-oriented design. The API implementation was selected as a starting point because it was not actively being modified, had relatively low complexity, and was already due for a refactor.  

Additionally, API-related code is a prime candidate for extraction into a standalone SDK, which would help standardize server communication and reduce the complexity of the main script.  

Beyond serving as a proof of concept, this PR lays the groundwork for a more maintainable, modular, and scalable codebase.  

## Changes Introduced:  
- Refactored the API into a dedicated, serialized `ApiClient` class.  
- Implemented proper HTTPS verification.  
- Improved API robustness and error handling.  
- Removed the incorrect handling of the `Retry-After` header (re-implementation still pending).  

## Known Issues:  
During development, an issue was identified with the HWA server’s handling of the `Retry-After` HTTP header. The server does not adhere to the HTTP specification, which mandates that the `Retry-After` value must be an integer. Instead, the server returns a floating-point value (e.g., `8945.1439112`).  

Previously, our implementation did not enforce strict type validation and was able to process the incorrect format. However, with the introduction of a proper HTTP handler, parsing the invalid `Retry-After` value now results in a `requests.RequestException: Invalid Retry-After header: 8945.1439112`.  

Further details on this specification requirement can be found in [RFC 6585, Section 4](https://datatracker.ietf.org/doc/html/rfc6585#section-4).  

### Blocking Issue:  
This PR cannot be merged until the corresponding server-side issue is resolved. More details on the status of this issue can be found [here](https://github.com/JPVenson/Jellyfin.HardwareVisualizer/issues/15).